### PR TITLE
Add Continuous Integration (CI)

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  main:
+    name: ${{ matrix.os }} ${{ matrix.build-type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest']
+        build-type: ['Debug', 'Release']
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: sudo apt-get install libnetcdf-dev libnetcdff-dev nco
+    
+    - name: Install SPARTACUS-Surface
+      run: |
+        if [ ${{ matrix.build-type }} = 'Debug' ]; then export DEBUG=1; fi
+        make PROFILE=gfortran
+    
+    - name: Run tests
+      run: make test


### PR DESCRIPTION
This PR adds Continuous Integration (CI) for SPARTACUS-Surface. The software is automatically compiled and tested at every push commit or pull request. In case of compile- run-time errors a notification is sent out. Currently, checks are only performed on the latest Ubuntu LTS with gfortran for Debug and Release mode but can be easily expanded if needed. 